### PR TITLE
fix: parallel option in OpusStream

### DIFF
--- a/src/transcoders/Opus.js
+++ b/src/transcoders/Opus.js
@@ -57,8 +57,8 @@ class OpusStream extends Transform {
         BaseOpus.count++;
         this.once('end', () => BaseOpus.count--);
       }
-      this._encode = async buffer => BaseOpus.do(this.encoder.encode(buffer)).run(options.parallel ? undefined : false);
-      this._decode = async buffer => BaseOpus.do(this.encoder.decode(buffer)).run(options.parallel ? undefined : false);
+      this._encode = buffer => BaseOpus.do(this.encoder.encode(buffer)).run(options.parallel ? undefined : false);
+      this._decode = buffer => BaseOpus.do(this.encoder.decode(buffer)).run(options.parallel ? undefined : false);
     }
     this._options = options;
     this._required = this._options.frameSize * this._options.channels * 2;

--- a/src/transcoders/Opus.js
+++ b/src/transcoders/Opus.js
@@ -57,8 +57,8 @@ class OpusStream extends Transform {
         BaseOpus.count++;
         this.once('end', () => BaseOpus.count--);
       }
-      this._encode = async buffer => await BaseOpus.do(this.encoder.encode(buffer)).run(options.parallel ? undefined : false);
-      this._decode = async buffer => await BaseOpus.do(this.encoder.decode(buffer)).run(options.parallel ? undefined : false);
+      this._encode = async buffer => BaseOpus.do(this.encoder.encode(buffer)).run(options.parallel ? undefined : false);
+      this._decode = async buffer => BaseOpus.do(this.encoder.decode(buffer)).run(options.parallel ? undefined : false);
     }
     this._options = options;
     this._required = this._options.frameSize * this._options.channels * 2;

--- a/src/transcoders/Opus.js
+++ b/src/transcoders/Opus.js
@@ -57,8 +57,8 @@ class OpusStream extends Transform {
         BaseOpus.count++;
         this.once('end', () => BaseOpus.count--);
       }
-      this._encode = async buffer => await BaseOpus.do(this.encoder.encode(buffer)).run();
-      this._decode = async buffer => await BaseOpus.do(this.encoder.decode(buffer)).run();
+      this._encode = async buffer => await BaseOpus.do(this.encoder.encode(buffer)).run(options.parallel ? undefined : false);
+      this._decode = async buffer => await BaseOpus.do(this.encoder.decode(buffer)).run(options.parallel ? undefined : false);
     }
     this._options = options;
     this._required = this._options.frameSize * this._options.channels * 2;


### PR DESCRIPTION
Right now krypton will run in parallel even if the option is set to false.